### PR TITLE
Add download functionality and better styling

### DIFF
--- a/components/Browser.js
+++ b/components/Browser.js
@@ -1,19 +1,66 @@
+import styled, { css } from 'styled-components'
+
+const BrowserContainer = styled.div`
+  padding: 32px;
+
+  ${props => props.width && css`
+    width: ${props.width + 64}px;
+  `}
+
+  ${props => props.height && css`
+    height: ${props.height + 64}px;
+  `}
+`
+
+const BrowserWindow = styled.div`
+  border-radius: 6px;
+  overflow: hidden;
+  box-shadow: 0px 0px 20px #acacac;;
+  border: 1px solid #acacac;
+`
+
+const TitleBar = styled.div`
+  background-image: linear-gradient(top, #ebebeb, #d5d5d5);
+  background: -webkit-linear-gradient(top, #ebebeb, #d5d5d5);
+  background-color: #4d494d;
+  border-top: 1px solid #f3f1f3;
+  border-bottom: 1px solid #b1aeb1;
+  height: 20px;
+`
+
+const TitleBarButtonContainer = styled.div`
+  padding: 2px 0 0 6px;
+`
+
+const TitleBarButton = styled.div`
+  width: 11px;
+  height: 11px;
+  display: inline-block;
+  border-radius: 50%;
+  margin-left: 6px;
+
+  ${props => props.bgColor && css`
+    background-color: ${props.bgColor};
+  `}
+
+  ${props => props.borderColor && css `
+    border: 1px solid ${props.borderColor};
+  `}
+`
+
 export default function Browser({ height, width, image, browserRef }) {
   return (
-      <svg width={width} height={height + 30} viewBox={`0 0 ${width} ${height + 30}`} fill="none"
-        ref={browserRef}
-        style={{
-          borderRadius: '8px 8px 8px 8px',
-          boxShadow: '0px 22px 70px 5px rgba(0,0,0,0.56)'
-        }}
-        xmlns="http://www.w3.org/2000/svg"
-        xmlnsXlink="http://www.w3.org/1999/xlink">
-        <rect x="0" y="0" width={width} height="30" fill="#E8E8E8" />
-        <circle cx="14" cy="15" r="6" fill="#EF1010"/>
-        <circle cx="30" cy="15" r="6" fill="#EFD910"/>
-        <circle cx="46" cy="15" r="6" fill="#14EF10"/>
-
-        <image y="30" width={width} height={height} xlinkHref={image} />
-      </svg>
+    <BrowserContainer ref={browserRef} height={height} width={width}>
+      <BrowserWindow>
+        <TitleBar>
+          <TitleBarButtonContainer>
+            <TitleBarButton bgColor={'#ff5c5c'} borderColor={'#e33e41'}/>
+            <TitleBarButton bgColor={'#ffbd4c'} borderColor={'#e09e3e'}/>
+            <TitleBarButton bgColor={'#00ca56'} borderColor={'#14ae46'}/>
+          </TitleBarButtonContainer>
+        </TitleBar>
+        <img src={image} />
+      </BrowserWindow>
+    </BrowserContainer>
   )
 }

--- a/components/Browser.js
+++ b/components/Browser.js
@@ -1,16 +1,19 @@
-export default function Browser({ height, width, image }) {
+export default function Browser({ height, width, image, browserRef }) {
   return (
-    <svg width={width} height={height + 30} viewBox={`0 0 ${width} ${height + 30}`} fill="none"
-      style={{
-        borderRadius: '8px 8px 8px 8px',
-        boxShadow: '0px 22px 70px 5px rgba(0,0,0,0.56)'
-      }}>
-      <rect x="0" y="0" width={width} height="30" fill="#E8E8E8" />
-      <circle cx="14" cy="15" r="6" fill="#EF1010"/>
-      <circle cx="30" cy="15" r="6" fill="#EFD910"/>
-      <circle cx="46" cy="15" r="6" fill="#14EF10"/>
+      <svg width={width} height={height + 30} viewBox={`0 0 ${width} ${height + 30}`} fill="none"
+        ref={browserRef}
+        style={{
+          borderRadius: '8px 8px 8px 8px',
+          boxShadow: '0px 22px 70px 5px rgba(0,0,0,0.56)'
+        }}
+        xmlns="http://www.w3.org/2000/svg"
+        xmlnsXlink="http://www.w3.org/1999/xlink">
+        <rect x="0" y="0" width={width} height="30" fill="#E8E8E8" />
+        <circle cx="14" cy="15" r="6" fill="#EF1010"/>
+        <circle cx="30" cy="15" r="6" fill="#EFD910"/>
+        <circle cx="46" cy="15" r="6" fill="#14EF10"/>
 
-      <image y="30" width={width} height={height} xlinkHref={image} />
-    </svg>
+        <image y="30" width={width} height={height} xlinkHref={image} />
+      </svg>
   )
 }

--- a/components/Download.js
+++ b/components/Download.js
@@ -1,0 +1,20 @@
+import htmlToImage from 'html-to-image'
+
+export default function Download({ browserRef }) {
+  const handleDownload = () => {
+    const svg = browserRef.current
+
+    htmlToImage.toPng(svg)
+      .then(function (dataUrl) {
+        const link = document.createElement('a')
+        link.download = 'test'
+        link.href = dataUrl
+
+        link.click()
+      });
+  }
+
+  return (
+      <button onClick={handleDownload}>Download</button>
+  )
+}

--- a/components/Sidebar.js
+++ b/components/Sidebar.js
@@ -1,31 +1,12 @@
 import { StyledSidebar } from './Sidebar.styles'
 import Logo from './Logo'
-import Canvg from 'canvg'
+import Download from './Download'
 
-export default function Sidebar({ browserRef }) {
-  const handleDownload = () => {
-    const svg = browserRef.current
-
-    const canvas = document.createElement('canvas')
-    const ctx = canvas.getContext('2d')
-    const v = Canvg.fromString(ctx, svg.outerHTML)
-    v.render().then(() => {
-      const base64 = canvas.toDataURL("image/png")
-
-      const link = document.createElement('a')
-      link.download = 'test'
-      link.href = base64
-
-      link.click()
-    })
-
-  }
-
+export default function Sidebar({ browserRef, image }) {
   return (
     <StyledSidebar>
       <Logo />
-
-      <button onClick={handleDownload}>Download</button>
+      {image && <Download browserRef={browserRef} />}
     </StyledSidebar>
   )
 }

--- a/components/Sidebar.js
+++ b/components/Sidebar.js
@@ -1,10 +1,31 @@
 import { StyledSidebar } from './Sidebar.styles'
 import Logo from './Logo'
+import Canvg from 'canvg'
 
-export default function Sidebar() {
+export default function Sidebar({ browserRef }) {
+  const handleDownload = () => {
+    const svg = browserRef.current
+
+    const canvas = document.createElement('canvas')
+    const ctx = canvas.getContext('2d')
+    const v = Canvg.fromString(ctx, svg.outerHTML)
+    v.render().then(() => {
+      const base64 = canvas.toDataURL("image/png")
+
+      const link = document.createElement('a')
+      link.download = 'test'
+      link.href = base64
+
+      link.click()
+    })
+
+  }
+
   return (
     <StyledSidebar>
       <Logo />
+
+      <button onClick={handleDownload}>Download</button>
     </StyledSidebar>
   )
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1428,11 +1428,6 @@
       "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.4.tgz",
       "integrity": "sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug=="
     },
-    "@types/raf": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.0.tgz",
-      "integrity": "sha512-taW5/WYqo36N7V39oYyHP9Ipfd5pNFvGTIQsNGj86xV88YQ7GnI30/yMfKDF7Zgin0m3e+ikX88FvImnK4RjGw=="
-    },
     "@webassemblyjs/ast": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.9.0.tgz",
@@ -2246,19 +2241,6 @@
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001099.tgz",
       "integrity": "sha512-sdS9A+sQTk7wKoeuZBN/YMAHVztUfVnjDi4/UV3sDE8xoh7YR12hKW+pIdB3oqKGwr9XaFL2ovfzt9w8eUI5CA=="
     },
-    "canvg": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.6.tgz",
-      "integrity": "sha512-eFUy8R/4DgocR93LF8lr+YUxW4PYblUe/Q1gz2osk/cI5n8AsYdassvln0D9QPhLXQ6Lx7l8hwtT8FLvOn2Ihg==",
-      "requires": {
-        "@babel/runtime": "^7.6.3",
-        "@types/raf": "^3.4.0",
-        "core-js": "3",
-        "raf": "^3.4.1",
-        "rgbcolor": "^1.0.1",
-        "stackblur-canvas": "^2.0.0"
-      }
-    },
     "chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -2485,11 +2467,6 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
-    },
-    "core-js": {
-      "version": "3.6.5",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
-      "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA=="
     },
     "core-js-compat": {
       "version": "3.6.5",
@@ -3754,6 +3731,11 @@
       "resolved": "https://registry.npmjs.org/html-comment-regex/-/html-comment-regex-1.1.2.tgz",
       "integrity": "sha512-P+M65QY2JQ5Y0G9KKdlDpo0zK+/OHptU5AaBwUfAIDJZk1MYf32Frm84EcOytfJE0t5JvkAnKlmjsXDnWzCJmQ=="
     },
+    "html-to-image": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/html-to-image/-/html-to-image-0.1.1.tgz",
+      "integrity": "sha512-UAjpXmokENeOyzfLwL0+zQ502lXyg6pkzVUmRjtljOH9dR/YdEYQhWrQ/O14hmH5/1L7jv1aOupU4Zi3Y8+iow=="
+    },
     "htmlparser2": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-4.1.0.tgz",
@@ -4850,11 +4832,6 @@
         "sha.js": "^2.4.8"
       }
     },
-    "performance-now": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
-    },
     "picomatch": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
@@ -5555,14 +5532,6 @@
       "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
       "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM="
     },
-    "raf": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
-      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
-      "requires": {
-        "performance-now": "^2.1.0"
-      }
-    },
     "randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -5833,11 +5802,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/rgba-regex/-/rgba-regex-1.0.0.tgz",
       "integrity": "sha1-QzdOLiyglosO8VI0YLfXMP8i7rM="
-    },
-    "rgbcolor": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
-      "integrity": "sha1-1lBezbMEplldom+ktDMHMGd1lF0="
     },
     "rimraf": {
       "version": "2.7.1",
@@ -6203,11 +6167,6 @@
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
       "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w=="
-    },
-    "stackblur-canvas": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.3.0.tgz",
-      "integrity": "sha512-3ZHJv+43D8YttgumssIxkfs3hBXW7XaMS5Ux65fOBhKDYMjbG5hF8Ey8a90RiiJ58aQnAhWbGilPzZ9rkIlWgQ=="
     },
     "stacktrace-parser": {
       "version": "0.1.10",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1428,6 +1428,11 @@
       "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.4.tgz",
       "integrity": "sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug=="
     },
+    "@types/raf": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.0.tgz",
+      "integrity": "sha512-taW5/WYqo36N7V39oYyHP9Ipfd5pNFvGTIQsNGj86xV88YQ7GnI30/yMfKDF7Zgin0m3e+ikX88FvImnK4RjGw=="
+    },
     "@webassemblyjs/ast": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.9.0.tgz",
@@ -2241,6 +2246,19 @@
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001099.tgz",
       "integrity": "sha512-sdS9A+sQTk7wKoeuZBN/YMAHVztUfVnjDi4/UV3sDE8xoh7YR12hKW+pIdB3oqKGwr9XaFL2ovfzt9w8eUI5CA=="
     },
+    "canvg": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.6.tgz",
+      "integrity": "sha512-eFUy8R/4DgocR93LF8lr+YUxW4PYblUe/Q1gz2osk/cI5n8AsYdassvln0D9QPhLXQ6Lx7l8hwtT8FLvOn2Ihg==",
+      "requires": {
+        "@babel/runtime": "^7.6.3",
+        "@types/raf": "^3.4.0",
+        "core-js": "3",
+        "raf": "^3.4.1",
+        "rgbcolor": "^1.0.1",
+        "stackblur-canvas": "^2.0.0"
+      }
+    },
     "chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -2467,6 +2485,11 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
+    },
+    "core-js": {
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
+      "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA=="
     },
     "core-js-compat": {
       "version": "3.6.5",
@@ -4827,6 +4850,11 @@
         "sha.js": "^2.4.8"
       }
     },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+    },
     "picomatch": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
@@ -5527,6 +5555,14 @@
       "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
       "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM="
     },
+    "raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "requires": {
+        "performance-now": "^2.1.0"
+      }
+    },
     "randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -5797,6 +5833,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/rgba-regex/-/rgba-regex-1.0.0.tgz",
       "integrity": "sha1-QzdOLiyglosO8VI0YLfXMP8i7rM="
+    },
+    "rgbcolor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
+      "integrity": "sha1-1lBezbMEplldom+ktDMHMGd1lF0="
     },
     "rimraf": {
       "version": "2.7.1",
@@ -6162,6 +6203,11 @@
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
       "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w=="
+    },
+    "stackblur-canvas": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.3.0.tgz",
+      "integrity": "sha512-3ZHJv+43D8YttgumssIxkfs3hBXW7XaMS5Ux65fOBhKDYMjbG5hF8Ey8a90RiiJ58aQnAhWbGilPzZ9rkIlWgQ=="
     },
     "stacktrace-parser": {
       "version": "0.1.10",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "start": "next start"
   },
   "dependencies": {
+    "canvg": "^3.0.6",
     "next": "9.4.4",
     "react": "16.13.1",
     "react-dom": "16.13.1",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "canvg": "^3.0.6",
+    "html-to-image": "^0.1.1",
     "next": "9.4.4",
     "react": "16.13.1",
     "react-dom": "16.13.1",

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,5 +1,5 @@
 import Head from 'next/head'
-import { useState } from 'react'
+import { useState, useRef } from 'react'
 import reset from 'styled-reset'
 import Sidebar from '../components/Sidebar'
 import Browser from '../components/Browser'
@@ -17,6 +17,7 @@ const SiteContainer = styled.main`
 
 export default function Home() {
   const [image, setImage] = useState({})
+  const browserWindow = useRef(null)
 
   return (
     <SiteContainer>
@@ -29,10 +30,10 @@ export default function Home() {
       </Head>
 
       {image.image
-        ? <Browser width={image.width} height={image.height} image={image.image} />
+        ? <Browser width={image.width} height={image.height} image={image.image} browserRef={browserWindow}/>
         : <ImageUpload setImage={setImage} />
       }
-      <Sidebar />
+      <Sidebar browserRef={browserWindow}/>
     </SiteContainer>
   )
 }

--- a/pages/index.js
+++ b/pages/index.js
@@ -33,7 +33,7 @@ export default function Home() {
         ? <Browser width={image.width} height={image.height} image={image.image} browserRef={browserWindow}/>
         : <ImageUpload setImage={setImage} />
       }
-      <Sidebar browserRef={browserWindow}/>
+      <Sidebar browserRef={browserWindow} image={image.image}/>
     </SiteContainer>
   )
 }


### PR DESCRIPTION
Rewrote the browser preview, so it now uses JSX elements that then gets translated to a PNG.

For future reference, grabbed some styling from here: https://codepen.io/JohJakob/pen/YPxgwo.

The viewport is pretty wonky, so if the uploaded image is bigger than the viewport it's currently not possible to see all of it — this will be addressed in a future branch. The download button is also not styled here, but I will do a branch for styling all of the inputs and sidebar.